### PR TITLE
Fix imports

### DIFF
--- a/whisper_online.py
+++ b/whisper_online.py
@@ -58,6 +58,7 @@ class WhisperTimestampedASR(ASRBase):
 
     def load_model(self, modelsize=None, cache_dir=None, model_dir=None):
         import whisper
+        import whisper_timestamped
         from whisper_timestamped import transcribe_timestamped
         self.transcribe_timestamped = transcribe_timestamped
         if model_dir is not None:
@@ -558,10 +559,8 @@ def asr_factory(args, logfile=sys.stderr):
         asr = OpenaiApiASR(lan=args.lan)
     else:
         if backend == "faster-whisper":
-            from faster_whisper import FasterWhisperASR
             asr_cls = FasterWhisperASR
         else:
-            from whisper_timestamped import WhisperTimestampedASR
             asr_cls = WhisperTimestampedASR
 
         # Only for FasterWhisperASR and WhisperTimestampedASR


### PR DESCRIPTION
Now, the ASR implementations do their own imports. No need to import in the factory.

Fixing the damage in #69 

Tested with:

`python whisper_online.py --min-chunk-size 5 ~/Spinoza.mp3` (defaults to faster-whisper)
`python whisper_online.py --backend faster-whisper --min-chunk-size 5 ~/Spinoza.mp3`
`python whisper_online.py --backend whisper_timestamped --min-chunk-size 5 ~/Spinoza.mp3`
`python whisper_online.py --backend openai-api --min-chunk-size 5 ~/Spinoza.mp3`
`python whisper_online_server.py --lan nl --host 0.0.0.0 --port 44000 --min-chunk-size 2` (defaults to faster-whisper)
`python whisper_online_server.py --backend openai-api --lan nl --host 0.0.0.0 --port 44000 --min-chunk-size 2`