### PR TITLE
Warmup file argument

### DIFF
--- a/whisper_online_server.py
+++ b/whisper_online_server.py
@@ -10,6 +10,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--host", type=str, default='localhost')
 parser.add_argument("--port", type=int, default=43007)
 
+parser.add_argument("--warmup-file", type=str, dest="warmup_file")
+
 
 # options from whisper_online
 add_shared_args(parser)
@@ -61,10 +63,9 @@ online = OnlineASRProcessor(asr,tokenizer,buffer_trimming=(args.buffer_trimming,
 
 
 
-demo_audio_path = "cs-maji-2.16k.wav"
-if os.path.exists(demo_audio_path):
+if os.path.exists(args.warmup_file):
     # load the audio into the LRU cache before we start the timer
-    a = load_audio_chunk(demo_audio_path,0,1)
+    a = load_audio_chunk(args.warmup_file,0,1)
 
     # TODO: it should be tested whether it's meaningful
     # warm up the ASR, because the very first transcribe takes much more time than the other

--- a/whisper_online_server.py
+++ b/whisper_online_server.py
@@ -63,7 +63,7 @@ online = OnlineASRProcessor(asr,tokenizer,buffer_trimming=(args.buffer_trimming,
 
 
 
-if os.path.exists(args.warmup_file):
+if args.warmup_file and os.path.exists(args.warmup_file):
     # load the audio into the LRU cache before we start the timer
     a = load_audio_chunk(args.warmup_file,0,1)
 


### PR DESCRIPTION
I don't have `cs-maji-2.16k.wav`, and I couldn't immediately see an option for getting it, so I've added a command-line argument for passing in a filename to use for the warmup.

To test, run with `--warmup-file <path to file>`.   I've been using `jfk.wav` from `whisper.cpp` just because I happen to have it handy and it's very short.