### PR TITLE
fix: pin silero-vad version to v4

### DIFF
--- a/whisper_online.py
+++ b/whisper_online.py
@@ -531,7 +531,7 @@ class VACOnlineASRProcessor(OnlineASRProcessor):
         # VAC:
         import torch
         model, _ = torch.hub.load(
-            repo_or_dir='snakers4/silero-vad',
+            repo_or_dir='snakers4/silero-vad:v4.0',
             model='silero_vad'
         )
         from silero_vad import VADIterator


### PR DESCRIPTION
seems there is a new version (v5) which cant handle sample sizes other than 512 for the 16kHz.
let fix it for now to not confuse others who are trying this repo :)