### PR TITLE
Add MLX Whisper Backend for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ Alternative, less restrictive, but slower backend is [whisper-timestamped](https
 
 Thirdly, it's also possible to run this software from the [OpenAI Whisper API](https://platform.openai.com/docs/api-reference/audio/createTranscription). This solution is fast and requires no GPU, just a small VM will suffice, but you will need to pay OpenAI for api access. Also note that, since each audio fragment is processed multiple times, the [price](https://openai.com/pricing) will be higher than obvious from the pricing page, so keep an eye on costs while using. Setting a higher chunk-size will reduce costs significantly. 
 Install with: `pip install openai` , [requires Python >=3.8](https://pypi.org/project/openai/).
-
 For running with the openai-api backend, make sure that your [OpenAI api key](https://platform.openai.com/api-keys) is set in the `OPENAI_API_KEY` environment variable. For example, before running, do: `export OPENAI_API_KEY=sk-xxx` with *sk-xxx* replaced with your api key. 
+
+Fourthly, another efficient backend is the [Whisper MLX](https://github.com/ml-explore/mlx-examples/tree/main/whisper)  library, optimized specifically for Apple Silicon. Whisper MLX leverages the performance capabilities of Apple chips (M1, M2...) to deliver faster transcription without requiring a GPU: `pip install mlx-whisper`. All the main whisper models have been converted to the MLX format, and are listed on [Hugging Face Whisper mlx](https://huggingface.co/collections/mlx-community/whisper-663256f9964fbb1177db93dc).
+
 
 The backend is loaded only when chosen. The unused one does not have to be installed.
 

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -190,11 +190,13 @@ class MLXWhisper(ASRBase):
         
         self.model_size_or_path = model_size_or_path
         
-        # In mlx_whisper.transcribe, dtype is defined as:
-        # dtype = mx.float16 if decode_options.get("fp16", True) else mx.float32
-        # Since we do not use decode_options in self.transcribe, we will set dtype to mx.float16
-        dtype = mx.float16 
-        ModelHolder.get_model(model_size_or_path, dtype) #Model is preloaded to avoid loading it every time
+        # Note: ModelHolder.get_model loads the model into a static class variable, 
+        # making it a global resource. This means:
+        # - Only one model can be loaded at a time; switching models requires reloading.
+        # - This approach may not be suitable for scenarios requiring multiple models simultaneously,
+        #   such as using whisper-streaming as a module with varying model sizes.
+        dtype = mx.float16 # Default to mx.float16. In mlx_whisper.transcribe: dtype = mx.float16 if decode_options.get("fp16", True) else mx.float32
+        ModelHolder.get_model(model_size_or_path, dtype) #Model is preloaded to avoid reloading during transcription
         
         return transcribe
     

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -158,7 +158,7 @@ class FasterWhisperASR(ASRBase):
 
 class MLXWhisper(ASRBase):
     """
-    Uses MPX Whisper library as the backend, optimized for Apple Silicon.
+    Uses MLX Whisper library as the backend, optimized for Apple Silicon.
     Models available: https://huggingface.co/collections/mlx-community/whisper-663256f9964fbb1177db93dc
     Significantly faster than faster-whisper (without CUDA) on Apple M1. 
     """

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -178,8 +178,9 @@ class MLXWhisper(ASRBase):
                 model_dir (str, optional): Direct path to a custom model directory. 
                     If specified, it overrides the `modelsize` parameter.
         """
-        from mlx_whisper import transcribe
-
+        from mlx_whisper.transcribe import ModelHolder, transcribe
+        import mlx.core as mx # Is installed with mlx-whisper
+        
         if model_dir is not None:
             logger.debug(f"Loading whisper model from model_dir {model_dir}. modelsize parameter is not used.")
             model_size_or_path = model_dir
@@ -188,6 +189,13 @@ class MLXWhisper(ASRBase):
             logger.debug(f"Loading whisper model {modelsize}. You use mlx whisper, so {model_size_or_path} will be used.")
         
         self.model_size_or_path = model_size_or_path
+        
+        # In mlx_whisper.transcribe, dtype is defined as:
+        # dtype = mx.float16 if decode_options.get("fp16", True) else mx.float32
+        # Since we do not use decode_options in self.transcribe, we will set dtype to mx.float16
+        dtype = mx.float16 
+        ModelHolder.get_model(model_size_or_path, dtype) #Model is preloaded to avoid loading it every time
+        
         return transcribe
     
     def translate_model_name(self, model_name):


### PR DESCRIPTION
Hi, 

As indicated in my [previous pull request](https://github.com/ufal/whisper_streaming/pull/146#issuecomment-2553357043), this PR concerns exclusively the mlx-whisper backend:

The Whisper MLX backend is optimized specifically for Apple Silicon. It uses the mlx-whisper library, which leverages the native performance capabilities of Apple hardware for faster transcription without requiring a dedicated GPU.

**Key Changes**

- MLXWhisper Backend: Added MLXWhisper as a new class in the backend options.
  - Automatically translates model names (e.g., large-v2) to MLX-compatible Hugging Face paths (e.g., whisper-large-v2-mlx).
  - No change to the --model parameter in the project CLI, model "translation" is done in the background.

- Readme has been updated with information & how to install (`pip install mlx-whisper`)

**Testing**
- The implementation has been tested on Apple M1. It works faster than faster whisper.

**Usage Example**

`python whisper_streaming.py --model "large-v3-turbo" --backend "mlx-whisper"`

The MLXWhisper class translates the model name to the Hugging Face path mlx-community/whisper-large-v3-turbo and loads the model efficiently.

Let me know if you have any questions or need further clarifications!

Best regards,
Quentin
