### PR TITLE
Add support sample rate 8000, basic requirements.txt and simple module init

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
 from .whisper_online import OnlineASRProcessor
+from .whisper_online import VACOnlineASRProcessor
 from .whisper_online import OpenaiApiASR
 from .whisper_online import create_tokenizer

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+from .whisper_online import OnlineASRProcessor
+from .whisper_online import OpenaiApiASR

--- a/__init__.py
+++ b/__init__.py
@@ -2,3 +2,4 @@
 
 from .whisper_online import OnlineASRProcessor
 from .whisper_online import OpenaiApiASR
+from .whisper_online import create_tokenizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai==1.65.3
+python-dotenv==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ python-dotenv==0.19.0
 librosa==0.6.3
 soundfile==0.10.3.post1
 numpy>=1.18.1
+tokenize-uk==0.2.0
+opus-fast-mosestokenizer==0.0.8.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 openai==1.65.3
 python-dotenv==0.19.0
+librosa==0.6.3
+soundfile==0.10.3.post1
+numpy>=1.18.1

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -275,13 +275,14 @@ class MLXWhisper(ASRBase):
 class OpenaiApiASR(ASRBase):
     """Uses OpenAI's Whisper API for audio transcription."""
 
-    def __init__(self, lan=None, temperature=0, logfile=sys.stderr):
+    def __init__(self, lan=None, temperature=0, logfile=sys.stderr, samplerate=16000):
         self.logfile = logfile
 
         self.modelname = "whisper-1"  
         self.original_language = None if lan == "auto" else lan # ISO-639-1 language code
         self.response_format = "verbose_json" 
         self.temperature = temperature
+        self.samplerate = samplerate
 
         self.load_model()
 
@@ -323,10 +324,10 @@ class OpenaiApiASR(ASRBase):
         # Write the audio data to a buffer
         buffer = io.BytesIO()
         buffer.name = "temp.wav"
-        sf.write(buffer, audio_data, samplerate=16000, format='WAV', subtype='PCM_16')
+        sf.write(buffer, audio_data, samplerate=self.samplerate, format='WAV', subtype='PCM_16')
         buffer.seek(0)  # Reset buffer's position to the beginning
 
-        self.transcribed_seconds += math.ceil(len(audio_data)/16000)  # it rounds up to the whole seconds
+        self.transcribed_seconds += math.ceil(len(audio_data)/self.samplerate)  # it rounds up to the whole seconds
 
         params = {
             "model": self.modelname,

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -10,6 +10,10 @@ import io
 import soundfile as sf
 import math
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 logger = logging.getLogger(__name__)
 
 @lru_cache(10**6)

--- a/whisper_online.py
+++ b/whisper_online.py
@@ -7,6 +7,7 @@ import time
 import logging
 
 import io
+import os
 import soundfile as sf
 import math
 
@@ -531,7 +532,7 @@ class OnlineASRProcessor:
 
     def chunk_completed_sentence(self):
         if self.commited == []: return
-        logger.debug(self.commited)
+        logger.debug('commited %s', self.commited)
         sents = self.words_to_sentences(self.commited)
         for s in sents:
             logger.debug(f"\t\tSENT: {s}")


### PR DESCRIPTION
1. Allow to import classes from other files and use it directly with sample rate 8000
2. Created an requirements.txt with basic dependencies
3. Removed VACOnlineASRProcessor extending OnlineASRProcessor because is not required as VACOnlineASRProcessor owns a OnlineASRProcessor.

@Gldkslfmsd @tijszwinkels @rodrigoGA
